### PR TITLE
Make it it work for current android (api 32) and flutter 2.10.2

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion flutter.compileSdkVersion
 
     lintOptions {
         disable 'InvalidPackage'
@@ -34,8 +34,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "co.appbrewery.xylophone"
-        minSdkVersion 23
-        targetSdkVersion 29
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"
+            android:exported="true"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
             android:hardwareAccelerated="true"


### PR DESCRIPTION
After these changes you can just hit play on Android Studio and the project works right away (tested on OSX on Android and iOS emulator)

to use it:

```
git clone https://github.com/londonappbrewery/xylophone-flutter.git
cd xylophone-flutter
git pull origin pull/44/head
```

Or directly clone my repo: https://github.com/philippkeller/xylophone-flutter